### PR TITLE
add bower.json file to allow installing with bower

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "jquery-disablescroll",
+  "version": "1.0.0",
+  "homepage": "https://github.com/ultrapasty/jquery-disablescroll",
+  "authors": [
+    "Josh Harrison"
+  ],
+  "description": "Disables scroll events from mousewheels, touchmoves and keypresses.",
+  "main": "jquery.disablescroll.js",
+  "keywords": [
+    "scroll",
+    "scrolling",
+    "disable",
+    "interaction",
+    "jquery"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I added a bower.json file to your library, so that it can be installed via `bower install jquery-disablescroll`.  Figured I'd add the MIT license file while I was at it as `bower init` prompted me for the license type.

If you are interested in this, I think you just need to make a git tag:

```
git tag -a 1.0.0
git push origin --tags
```

and register the package on bower:
http://bower.io/docs/creating-packages/#register

Thanks for the library :sun_with_face: 
